### PR TITLE
Allow credit invoices

### DIFF
--- a/basicvalidators.go
+++ b/basicvalidators.go
@@ -13,7 +13,7 @@ import (
 // Helper function to validate if the string is a valid currency format (with 2 decimal places)
 func IsValidCurrencyFormat(amount string) bool {
 	// Regex pattern to match valid decimal with exactly two decimal places
-	validCurrency := regexp.MustCompile(`^\d+(\.\d{2})$`)
+	validCurrency := regexp.MustCompile(`^-?\d+(\.\d{2})$`)
 	return validCurrency.MatchString(amount)
 }
 

--- a/basicvalidators_test.go
+++ b/basicvalidators_test.go
@@ -46,27 +46,27 @@ func TestCheckCurrency(t *testing.T) {
 
 	// Test an invalid currency
 	if IsValidCurrencyFormat("abc") {
-		t.Fatalf("Expected currency 100 to be invalid")
+		t.Fatalf("Expected currency abc to be invalid")
 	}
 
 	// Test an invalid currency
 	if IsValidCurrencyFormat("abc.fg") {
-		t.Fatalf("Expected currency 100 to be invalid")
+		t.Fatalf("Expected currency abc.fg to be invalid")
 	}
 
 	// Test an invalid currency
 	if IsValidCurrencyFormat("abc.23") {
-		t.Fatalf("Expected currency 100 to be invalid")
+		t.Fatalf("Expected currency abc.23 to be invalid")
 	}
 
 	// Test an invalid currency
 	if IsValidCurrencyFormat("100.ab") {
-		t.Fatalf("Expected currency 100 to be invalid")
+		t.Fatalf("Expected currency 100.ab to be invalid")
 	}
 
 	// Test negative currency
-	if IsValidCurrencyFormat("-100.00") {
-		t.Fatalf("Expected currency 100 to be invalid")
+	if !IsValidCurrencyFormat("-100.00") {
+		t.Fatalf("Expected currency -100.00 to be valid")
 	}
 
 	//Test zero


### PR DESCRIPTION
The library currently allows only positive amounts to be reported.
This change allows negative amounts to be reported as well to represent a credit to an existing invoice.
Please, let me know if crediting works differently according to the Croatian tax authority system.