### PR TITLE
Add optional libxml2 validation

### DIFF
--- a/README-HR.md
+++ b/README-HR.md
@@ -38,6 +38,7 @@ Iako postoji mnogo open-source implementacija libraryja za fiskalizaciju, one su
 - Prikladno za bilo koju vrstu aplikacije (web servis, web aplikacija, desktop aplikacija).
 - Ekstrakcija i vraćanje detalja certifikata kao što su javni ključ, izdavatelj, subjekt, serijski broj i razdoblje valjanosti.
 - Pomoćne funkcije za generiranje QR koda za ispis na računima u raznim formatima.
+- Opcionalna provjera CIS odgovora uz libxml2 kada se kompilira s oznakom `libxml2` na Linuxu.
 
 ### Go Verzija Kompatibilnost
 - Minimalna testirana i podržana verzija: **Go 1.22**

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ While there are numerous open-source implementations of Croatian fiscalization l
 - Suitable for any type of application (web service, web app, desktop)
 - Extract and return certificate details such as public key, issuer, subject, serial number, and validity period.
 - Helper function to get data for QR code (that can be passed to a QR code generator of your choice)
+- Optional libxml2 based validation of CIS responses when built with the `libxml2` tag on Linux
 
 ## Go Version Compatibility
 - Minimum tested and supported version: **Go 1.22**

--- a/dsignandverify.go
+++ b/dsignandverify.go
@@ -183,5 +183,8 @@ func (fe *FiskalEntity) signXML(xmlRequest []byte) ([]byte, error) {
 // This limitation will remain unresolved until a suitable library is found or a custom implementation is built,
 // or until fixes are contributed and merged into existing libraries.
 func (fe *FiskalEntity) verifyXML(xmlData []byte) (bool, error) {
+	if fe.useLibxml2 {
+		return fe.verifyXMLLibxml(xmlData)
+	}
 	return true, nil
 }

--- a/fiskalhr.go
+++ b/fiskalhr.go
@@ -57,6 +57,11 @@ type FiskalEntity struct {
 	// url is the endpoint URL for the CIS service.
 	// This URL is used to send fiscalization requests to the CIS system.
 	url string
+
+	// useLibxml2 indicates whether libxml2 should be used for
+	// validating CIS responses. This is currently supported only on
+	// Linux when compiled with the `libxml2` build tag.
+	useLibxml2 bool
 }
 
 // NewFiskalEntity creates a new FiskalEntity with provided values, validates certificates and input before returning an entity.
@@ -179,6 +184,18 @@ func (fe *FiskalEntity) CentralizedInvoiceNumber() bool {
 // DemoMode indicates whether the entity is in demo mode (Demo Fiskalizacija).
 func (fe *FiskalEntity) DemoMode() bool {
 	return fe.demoMode
+}
+
+// SetUseLibxml2 enables or disables libxml2 based validation of CIS
+// responses. Validation using libxml2 is only available on Linux and
+// when the library is compiled with the `libxml2` build tag.
+func (fe *FiskalEntity) SetUseLibxml2(enable bool) {
+	fe.useLibxml2 = enable
+}
+
+// UseLibxml2 reports whether libxml2 based validation is enabled.
+func (fe *FiskalEntity) UseLibxml2() bool {
+	return fe.useLibxml2
 }
 
 func (fe *FiskalEntity) DisplayCertInfoText() string {

--- a/verify_helpers.go
+++ b/verify_helpers.go
@@ -1,0 +1,55 @@
+package fiskalhrgo
+
+import (
+	"errors"
+	"strings"
+)
+
+// extractSignatureParts extracts the SignedInfo element and SignatureValue
+// from the provided XML data. It returns the canonical SignedInfo XML and
+// the base64 encoded SignatureValue.
+func extractSignatureParts(xmlData []byte) ([]byte, []byte, error) {
+	s := string(xmlData)
+	startSig := strings.Index(s, "<ds:Signature")
+	closeSig := "</ds:Signature>"
+	if startSig == -1 {
+		startSig = strings.Index(s, "<Signature")
+		closeSig = "</Signature>"
+	}
+	if startSig == -1 {
+		return nil, nil, errors.New("signature not found")
+	}
+	endSig := strings.Index(s[startSig:], closeSig)
+	if endSig == -1 {
+		return nil, nil, errors.New("signature not closed")
+	}
+	endSig += startSig + len(closeSig)
+	sigBlock := s[startSig:endSig]
+
+	startInfo := strings.Index(sigBlock, "<ds:SignedInfo")
+	closeInfo := "</ds:SignedInfo>"
+	if startInfo == -1 {
+		startInfo = strings.Index(sigBlock, "<SignedInfo")
+		closeInfo = "</SignedInfo>"
+	}
+	if startInfo == -1 {
+		return nil, nil, errors.New("SignedInfo not found")
+	}
+	endInfo := strings.Index(sigBlock[startInfo:], closeInfo)
+	if endInfo == -1 {
+		return nil, nil, errors.New("SignedInfo not closed")
+	}
+	endInfo += startInfo + len(closeInfo)
+	signedInfoStr := sigBlock[startInfo:endInfo]
+
+	startVal := strings.Index(sigBlock, "<SignatureValue>")
+	if startVal == -1 {
+		return nil, nil, errors.New("SignatureValue not found")
+	}
+	endVal := strings.Index(sigBlock[startVal:], "</SignatureValue>")
+	if endVal == -1 {
+		return nil, nil, errors.New("SignatureValue not closed")
+	}
+	value := strings.TrimSpace(sigBlock[startVal+len("<SignatureValue>") : startVal+endVal])
+	return []byte(signedInfoStr), []byte(value), nil
+}

--- a/verify_libxml2_linux.go
+++ b/verify_libxml2_linux.go
@@ -1,0 +1,70 @@
+//go:build libxml2 && linux
+
+package fiskalhrgo
+
+/*
+#cgo pkg-config: libxml-2.0
+#include <libxml/parser.h>
+#include <libxml/c14n.h>
+#include <stdlib.h>
+
+int canonicalize(char* xml, int xmlLen, char **out) {
+    xmlDocPtr doc = xmlReadMemory(xml, xmlLen, NULL, NULL, 0);
+    if (doc == NULL) return -1;
+    int ret = xmlC14NDocDumpMemory(doc, NULL, XML_C14N_1_0, NULL, 0, (xmlChar**)out);
+    xmlFreeDoc(doc);
+    return ret;
+}
+
+void freeCanon(char* p) {
+    xmlFree(p);
+}
+*/
+import "C"
+
+import (
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha1"
+	"encoding/base64"
+	"errors"
+	"unsafe"
+)
+
+func canonicalizeWithLibxml2(data []byte) ([]byte, error) {
+	if len(data) == 0 {
+		return nil, errors.New("no data")
+	}
+	cxml := (*C.char)(unsafe.Pointer(&data[0]))
+	var out *C.char
+	res := C.canonicalize(cxml, C.int(len(data)), &out)
+	if res < 0 {
+		return nil, errors.New("libxml2 canonicalization failed")
+	}
+	defer C.freeCanon(out)
+	return C.GoBytes(unsafe.Pointer(out), res), nil
+}
+
+func (fe *FiskalEntity) verifyXMLLibxml(xmlData []byte) (bool, error) {
+	signedInfo, sigValue, err := extractSignatureParts(xmlData)
+	if err != nil {
+		return false, err
+	}
+	canonical, err := canonicalizeWithLibxml2(signedInfo)
+	if err != nil {
+		return false, err
+	}
+	hash := sha1.Sum(canonical)
+	sigBytes, err := base64.StdEncoding.DecodeString(string(sigValue))
+	if err != nil {
+		return false, err
+	}
+	pub, ok := fe.ciscert.PublicCert.PublicKey.(*rsa.PublicKey)
+	if !ok {
+		return false, errors.New("invalid public key type")
+	}
+	if err := rsa.VerifyPKCS1v15(pub, crypto.SHA1, hash[:], sigBytes); err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/verify_libxml2_stub.go
+++ b/verify_libxml2_stub.go
@@ -1,0 +1,9 @@
+//go:build !libxml2 || !linux
+
+package fiskalhrgo
+
+import "errors"
+
+func (fe *FiskalEntity) verifyXMLLibxml(xmlData []byte) (bool, error) {
+	return false, errors.New("libxml2 validation not supported")
+}


### PR DESCRIPTION
## Summary
- add `useLibxml2` flag to `FiskalEntity`
- provide `SetUseLibxml2` and `UseLibxml2` helpers
- implement libxml2-based verification behind `libxml2` build tag
- add stub for non-linux/non-libxml2 builds
- document new feature in READMEs
